### PR TITLE
Pass `buildSchemaUrl` through SertoUiContext and avoid breaking React rules of hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'prettier',
     'prettier/@typescript-eslint',
+    'plugin:react-hooks/recommended',
   ],
   rules: {
     "@typescript-eslint/no-explicit-any": "off",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/serto-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "dist/serto-ui.js",
   "types": "dist/serto-ui.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@typescript-eslint/parser": "^4.14.1",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.2.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "install-peers-cli": "^2.2.0",
     "prettier": "2.2.1",
     "rimraf": "^3.0.2"

--- a/src/components/views/Credentials/IssueVc/IssueVcForm.tsx
+++ b/src/components/views/Credentials/IssueVc/IssueVcForm.tsx
@@ -24,10 +24,10 @@ export const IssueVcForm: React.FunctionComponent<IssueVcFormProps> = (props) =>
     "@context": ["https://www.w3.org/2018/credentials/v1"],
     // "id": "uuid:9110652b-3676-4720-8139-9163b244680d", // @TODO Should the API generate this?
     type: ["VerifiableCredential"],
-    issuer: { id: identifiers[0].did },
+    issuer: { id: identifiers[0]?.did },
     issuanceDate: new Date().toISOString(),
     credentialSubject: {
-      id: subjectIdentifier?.did || identifiers[0].did,
+      id: subjectIdentifier?.did || identifiers[0]?.did,
       exampleData: {
         foo: 123,
         bar: true,
@@ -39,7 +39,7 @@ export const IssueVcForm: React.FunctionComponent<IssueVcFormProps> = (props) =>
   const [error, setError] = useState<string | undefined>();
   const [vcData, setVcData] = useState<{ [key: string]: any }>({});
   const [rawJsonVc, setRawJsonVc] = useState(JSON.stringify(initialCred, null, 2));
-  const [issuer, setIssuer] = useState<string>(identifiers[0].did);
+  const [issuer, setIssuer] = useState<string>(identifiers[0]?.did);
   const [revocable, setRevocable] = useState<boolean>(true);
   const [keepCopy, setKeepCopy] = useState<boolean>(true);
 
@@ -157,7 +157,7 @@ export const IssueVcForm: React.FunctionComponent<IssueVcFormProps> = (props) =>
                   onChange={setIssuer}
                   value={issuer}
                   identifiers={identifiers}
-                  defaultSelectedDid={identifiers[0].did}
+                  defaultSelectedDid={identifiers[0]?.did}
                   required={true}
                   ownDidsOnly={true}
                 />

--- a/src/components/views/Credentials/IssueVc/IssueVcForm.tsx
+++ b/src/components/views/Credentials/IssueVc/IssueVcForm.tsx
@@ -77,7 +77,7 @@ export const IssueVcForm: React.FunctionComponent<IssueVcFormProps> = (props) =>
     let ldContext: string | any = schemaInstance.schema["@context"]["@metadata"]?.uris?.jsonLdContext;
     if (!ldContext) {
       console.warn("Could not find JSON-LD context URL - embedding entire context in VC");
-      ldContext = schemaInstance.jsonLdContext;
+      ldContext = schemaInstance.jsonLdContext["@context"];
     }
 
     const jsonSchemaUrl = schemaInstance.schema["@context"]["@metadata"]?.uris?.jsonSchema;

--- a/src/components/views/Schemas/CreateSchema/ConfirmStep.tsx
+++ b/src/components/views/Schemas/CreateSchema/ConfirmStep.tsx
@@ -4,6 +4,7 @@ import { SchemaDetail } from "../SchemaDetail";
 import { CompletedSchema, WorkingSchema } from "../types";
 import { createSchemaInput } from "../utils";
 import { ModalContent, ModalHeader } from "../../../elements/Modals";
+import { SertoUiContext, SertoUiContextInterface } from "../../../../context/SertoUiContext";
 
 export interface ConfirmStepProps {
   schema: WorkingSchema;
@@ -13,12 +14,13 @@ export interface ConfirmStepProps {
 
 export const ConfirmStep: React.FunctionComponent<ConfirmStepProps> = (props) => {
   const { schema } = props;
+  const context = React.useContext<SertoUiContextInterface>(SertoUiContext);
 
   return (
     <>
       <ModalHeader>Review Schema</ModalHeader>
       <ModalContent>
-        <SchemaDetail schema={createSchemaInput(schema as CompletedSchema)} />
+        <SchemaDetail schema={createSchemaInput(schema as CompletedSchema, context.buildSchemaUrl)} />
         <Button mt={3} width="100%" onClick={props.onComplete} disabled={props.loading}>
           {props.loading ? <Loader color="white" /> : "Publish"}
         </Button>

--- a/src/components/views/Schemas/CreateSchema/index.tsx
+++ b/src/components/views/Schemas/CreateSchema/index.tsx
@@ -66,7 +66,7 @@ export const CreateSchema: React.FunctionComponent<CreateSchemaProps> = (props) 
   }
 
   async function createSchema() {
-    const schemaInput = createSchemaInput(schema as CompletedSchema);
+    const schemaInput = createSchemaInput(schema as CompletedSchema, context.buildSchemaUrl);
     onSchemaCreated?.(schemaInput.ldContextPlus);
     await context.createSchema(schemaInput);
     mutate(["/v1/schemas", false]);

--- a/src/components/views/Schemas/utils.ts
+++ b/src/components/views/Schemas/utils.ts
@@ -1,9 +1,8 @@
-import * as React from "react";
 import { mapValuesDeep } from "deepdash-es/standalone";
 import { convertToPascalCase } from "../../../utils";
 import { VcSchema, jsonLdContextTypeMap, LdContextPlus, LdContextPlusNode } from "vc-schema-tools";
 import { CompletedSchema, SchemaMetadata, SchemaDataInput, newSchemaAttribute } from "./types";
-import { SertoUiContext, SertoUiContextInterface } from "../../../context/SertoUiContext";
+import { SertoUiContextInterface } from "../../../context/SertoUiContext";
 
 /** Adding `niceName` so that we can know what type to show in type selection dropdown. */
 type NamedLdContextPlusNode = Partial<LdContextPlusNode<SchemaMetadata>> & { niceName?: string };
@@ -31,8 +30,11 @@ typeOptions[NESTED_TYPE_KEY] = {
   niceName: "[nest attributes]",
 };
 
-export function createSchemaInput(schema: CompletedSchema): SchemaDataInput {
-  const schemaInstance = new VcSchema(createLdContextPlusSchema(schema));
+export function createSchemaInput(
+  schema: CompletedSchema,
+  buildSchemaUrl: SertoUiContextInterface["buildSchemaUrl"],
+): SchemaDataInput {
+  const schemaInstance = new VcSchema(createLdContextPlusSchema(schema, buildSchemaUrl));
   const schemaInput = { ...schema };
   delete (schemaInput as any).properties;
   return {
@@ -43,7 +45,10 @@ export function createSchemaInput(schema: CompletedSchema): SchemaDataInput {
   };
 }
 
-export function createLdContextPlusSchema(schema: CompletedSchema): LdContextPlus<SchemaMetadata> {
+export function createLdContextPlusSchema(
+  schema: CompletedSchema,
+  buildSchemaUrl: SertoUiContextInterface["buildSchemaUrl"],
+): LdContextPlus<SchemaMetadata> {
   const schemaTypeName = convertToPascalCase(schema.name);
 
   // Prefix each `@id` value with "schema-id:" to make it a valid JSON-LD Context identifier:
@@ -107,9 +112,4 @@ export function ldContextPlusToSchemaInput(ldContextPlus: LdContextPlus<SchemaMe
     ldContext: schemaInstance.getJsonLdContextString(),
     jsonSchema: schemaInstance.getJsonSchemaString(),
   };
-}
-
-export function buildSchemaUrl(slug: string, type: "ld-context-plus" | "ld-context" | "json-schema"): string {
-  const context = React.useContext<SertoUiContextInterface>(SertoUiContext);
-  return `${context.schemaHostBaseUrl}/v1/schemas/public/${slug}/${type}.json`;
 }

--- a/src/context/SertoUiContext.tsx
+++ b/src/context/SertoUiContext.tsx
@@ -7,20 +7,20 @@ import { NavItemProps } from "../components/layouts/Global/Nav";
 export interface SertoUiContextInterface {
   navItems: NavItemProps[];
 
-  /** Base URL on which schema JSON URLs will be built according to `getSchemaUrl` util. */
-  schemaHostBaseUrl: string;
   /** URL or path to send user to in order for them to create a schema. */
   createSchemaUrl: string;
+  /** Build URL at which a given schema will be hosted. */
+  buildSchemaUrl(slug: string, type: "ld-context-plus" | "ld-context" | "json-schema"): string;
   createSchema(schema: SchemaDataInput): Promise<any>;
   getSchemas(global?: boolean): Promise<SchemaDataResponse[]>;
   issueVc(body: any): Promise<any>;
 }
 
 const createMockApiRequest = (response?: any) => {
-  return (async () => {
+  return (async (...args: any[]) => {
     return new Promise((resolve) =>
       setTimeout(() => {
-        console.log("SertoUiContext mock API request resolving");
+        console.log("SertoUiContext mock API request resolving. Request args:", ...args);
         resolve(response);
       }, 500),
     );
@@ -32,7 +32,7 @@ export const defaultSertoUiContext: SertoUiContextInterface = {
     { text: "Home", url: "/", icon: Home },
     { text: "Nowhere", url: "/nowhere", icon: Send },
   ],
-  schemaHostBaseUrl: "https://alpha.consensysidentity.com",
+  buildSchemaUrl: (slug, type) => `https://example.com/schemas/${slug}/${type}.json`,
   createSchemaUrl: "/schemas/",
   createSchema: createMockApiRequest(),
   getSchemas: createMockApiRequest([]),


### PR DESCRIPTION
Was getting the dreaded "Invalid Hook Call Warning" and it required some refactoring.