### PR TITLE
Fetch and use schema in VC component to improve VC display

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/serto-ui",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "main": "dist/serto-ui.js",
   "types": "dist/serto-ui.d.ts",
   "scripts": {

--- a/src/components/views/Credentials/Credential.stories.tsx
+++ b/src/components/views/Credentials/Credential.stories.tsx
@@ -1,9 +1,22 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { EXAMPLE_VCS } from "vc-schema-tools";
+import { EXAMPLE_VCS, EXAMPLE_SCHEMAS } from "vc-schema-tools";
 import { Credential, CredentialViewTypes } from "./Credential";
 import { IdentityThemeProvider } from "../../../themes/IdentityTheme";
 import { BrowserRouter } from "react-router-dom";
+import { SertoUiProvider } from "../../../context/SertoUiProvider";
+import { createMockApiRequest } from "../../../utils/helpers";
+import { ldContextPlusToSchemaInput } from "../Schemas/utils";
+
+const schemas = Object.values(EXAMPLE_SCHEMAS)
+  .map((schema) => {
+    try {
+      return ldContextPlusToSchemaInput(JSON.parse(schema));
+    } catch {
+      return undefined;
+    }
+  })
+  .filter((schema) => !!schema);
 
 const farFutureDate = new Date("05 October 2081 14:48 UTC");
 const pastDate = new Date("05 October 2020 14:48 UTC");
@@ -49,7 +62,17 @@ const contentPubVc = {
 storiesOf("Credential", module)
   .addDecorator((story) => (
     <BrowserRouter>
-      <IdentityThemeProvider>{story()}</IdentityThemeProvider>
+      <IdentityThemeProvider>
+        <SertoUiProvider
+          context={{
+            schemasService: {
+              getSchemas: createMockApiRequest(schemas),
+            },
+          }}
+        >
+          {story()}
+        </SertoUiProvider>
+      </IdentityThemeProvider>
     </BrowserRouter>
   ))
   .add("List view", () => <Credential vc={diplomaVc} viewType={CredentialViewTypes.LIST} />)

--- a/src/components/views/Credentials/Credential.tsx
+++ b/src/components/views/Credentials/Credential.tsx
@@ -132,7 +132,7 @@ export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
               <Flex flexDirection="column" justifyContent="flex-end" alignItems="flex-end">
                 {subjectDomains &&
                   subjectDomains.map((domain) => (
-                    <DomainLink to={`/search?filter=${domain}`}>
+                    <DomainLink to={`/search?filter=${domain}`} key={domain}>
                       <Flex>
                         <Text fontFamily={fonts.sansSerif} fontWeight={2} fontSize={2} mr={2}>
                           {domain}
@@ -162,7 +162,7 @@ export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
               <Flex flexDirection="column" justifyContent="flex-end" alignItems="flex-end">
                 {issuerDomains &&
                   issuerDomains.map((domain) => (
-                    <DomainLink to={`/search?filter=${domain}`}>
+                    <DomainLink to={`/search?filter=${domain}`} key={domain}>
                       <Flex>
                         <Text fontFamily={fonts.sansSerif} fontWeight={2} fontSize={2} mr={2}>
                           {domain}
@@ -210,7 +210,12 @@ export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
       <Table border={0} boxShadow={0} width="100%" style={{ tableLayout: "fixed" }}>
         <tbody>
           {Object.entries(vc.credentialSubject).map(([key, value]) => (
-            <CredentialProperty key={key} keyName={key} value={value} />
+            <CredentialProperty
+              key={key}
+              keyName={key}
+              value={value}
+              schema={vcSchema?.jsonSchema?.properties?.credentialSubject?.properties?.[key]}
+            />
           ))}
         </tbody>
       </Table>

--- a/src/components/views/Credentials/Credential.tsx
+++ b/src/components/views/Credentials/Credential.tsx
@@ -10,6 +10,7 @@ import { dateTimeFormat, ellipsis } from "../../../utils";
 import { AdditionalVCData } from "../../../types";
 import { DomainImage } from "../../elements";
 import { DomainLink } from "../../elements/DomainLink";
+import { useVcSchema } from "../../../services/useVcSchema";
 import { CredentialProperty } from "./CredentialProperty";
 
 export enum CredentialViewTypes {
@@ -26,6 +27,8 @@ export interface CredentialProps {
 
 export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
   const { vc, additionalVCData } = props;
+  const { vcSchema } = useVcSchema(vc);
+  console.log("NICE WE HAVE SCHEMA", vcSchema);
   const vcType = vc.type[vc.type.length - 1];
   const issuer = typeof vc.issuer === "string" ? vc.issuer : vc.issuer.id;
   const viewType = props.viewType || "default";

--- a/src/components/views/Credentials/Credential.tsx
+++ b/src/components/views/Credentials/Credential.tsx
@@ -1,22 +1,16 @@
 import * as React from "react";
 import { Info, Person, VerifiedUser, Warning } from "@rimble/icons";
-import { Box, Flex, Pill, Table, Text, Tooltip } from "rimble-ui";
+import { Box, Flex, Pill, Table, Text } from "rimble-ui";
 import { VC } from "vc-schema-tools";
-import {
-  CredentialBorder,
-  CredentialContainer,
-  CredentialTDLeft,
-  CredentialTDRight,
-  CredentialTR,
-  Separator,
-} from "./CredentialComponents";
+import { CredentialBorder, CredentialContainer, Separator } from "./CredentialComponents";
 import { CopyToClipboard } from "../../elements/CopyToClipboard/CopyToClipboard";
 import { Expand } from "../../elements/Expand/Expand";
 import { baseColors, colors, fonts } from "../../../themes";
-import { dateTimeFormat, ellipsis, hexEllipsis } from "../../../utils";
+import { dateTimeFormat, ellipsis } from "../../../utils";
 import { AdditionalVCData } from "../../../types";
 import { DomainImage } from "../../elements";
 import { DomainLink } from "../../elements/DomainLink";
+import { CredentialProperty } from "./CredentialProperty";
 
 export enum CredentialViewTypes {
   COLLAPSIBLE = "COLLAPSIBLE",
@@ -94,44 +88,6 @@ export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
       </Box>
     </>
   );
-
-  const renderCredentialProperty = (key: string, value: any, nestedLevel = 0, parentKey = ""): JSX.Element => {
-    let valueDisplay = "";
-    let valueTooltip = "";
-    if (value === "boolean" || Array.isArray(value)) {
-      valueDisplay = JSON.stringify(value);
-    } else if (typeof value === "string" && value.indexOf("0x") !== -1) {
-      valueDisplay = hexEllipsis(value);
-      valueTooltip = value;
-    } else if (value && typeof value !== "object") {
-      valueDisplay = value;
-    }
-
-    return (
-      <React.Fragment key={parentKey + key}>
-        <CredentialTR key={parentKey + key}>
-          <CredentialTDLeft>
-            <Box pl={nestedLevel * 24}>{key}</Box>
-          </CredentialTDLeft>
-          <CredentialTDRight>
-            {valueTooltip ? (
-              <Tooltip message={valueTooltip} placement="top">
-                <Box>{valueDisplay}</Box>
-              </Tooltip>
-            ) : (
-              valueDisplay
-            )}
-          </CredentialTDRight>
-        </CredentialTR>
-        {value &&
-          typeof value === "object" &&
-          !Array.isArray(value) &&
-          Object.entries(value).map(([nestedKey, nestedValue]) =>
-            renderCredentialProperty(nestedKey, nestedValue, nestedLevel + 1, parentKey + key),
-          )}
-      </React.Fragment>
-    );
-  };
 
   const VerifiedCredentialAdditionalDetails = () => (
     <>
@@ -247,7 +203,9 @@ export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
     <>
       <Table border={0} boxShadow={0} width="100%" style={{ tableLayout: "fixed" }}>
         <tbody>
-          {Object.entries(vc.credentialSubject).map(([key, value]) => renderCredentialProperty(key, value))}
+          {Object.entries(vc.credentialSubject).map(([key, value]) => (
+            <CredentialProperty key={key} keyName={key} value={value} />
+          ))}
         </tbody>
       </Table>
       <Box my={2}>

--- a/src/components/views/Credentials/Credential.tsx
+++ b/src/components/views/Credentials/Credential.tsx
@@ -12,6 +12,7 @@ import { DomainImage } from "../../elements";
 import { DomainLink } from "../../elements/DomainLink";
 import { useVcSchema } from "../../../services/useVcSchema";
 import { CredentialProperty } from "./CredentialProperty";
+import { ViewSchemaButton } from "../Schemas/ViewSchemaButton";
 
 export enum CredentialViewTypes {
   COLLAPSIBLE = "COLLAPSIBLE",
@@ -28,7 +29,6 @@ export interface CredentialProps {
 export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
   const { vc, additionalVCData } = props;
   const { vcSchema } = useVcSchema(vc);
-  console.log("NICE WE HAVE SCHEMA", vcSchema);
   const vcType = vc.type[vc.type.length - 1];
   const issuer = typeof vc.issuer === "string" ? vc.issuer : vc.issuer.id;
   const viewType = props.viewType || "default";
@@ -77,16 +77,19 @@ export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
         </Box>
         <Box flexGrow="1">
           <Flex alignItems="center" justifyContent="flex-end">
-            <Pill color={colors.info.base} fontFamily={fonts.sansSerif} fontSize={0} height={4} mr={2}>
-              {vcType}
-            </Pill>
+            <ViewSchemaButton schema={vcSchema}>
+              <Pill color={colors.info.base} fontFamily={fonts.sansSerif} fontSize={0} height={4} mr={2}>
+                {vcType}
+                {vcSchema?.icon && ` ${vcSchema.icon}`}
+              </Pill>
+            </ViewSchemaButton>
             <VerifiedUser color={colors.primary.disabled[1]} />
           </Flex>
         </Box>
       </Flex>
       <Box>
         <Text color={baseColors.black} fontFamily={fonts.sansSerif} fontSize={2} fontWeight={3} mr={2}>
-          {vc.credentialSubject.title || vcType}
+          {vcSchema?.name || vc.credentialSubject.title || vcType}
         </Text>
       </Box>
     </>

--- a/src/components/views/Credentials/CredentialProperty.tsx
+++ b/src/components/views/Credentials/CredentialProperty.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { Box, Tooltip } from "rimble-ui";
+import { hexEllipsis } from "../../../utils/helpers";
+import { CredentialTDLeft, CredentialTDRight, CredentialTR } from "./CredentialComponents";
+
+export interface CredentialPropertyProps {
+  keyName: string /** "key" prop name is reserved by React */;
+  value: any;
+  nestedLevel?: number;
+  parentKey?: string;
+}
+
+export const CredentialProperty: React.FunctionComponent<CredentialPropertyProps> = (props) => {
+  const { keyName, value } = props;
+  const nestedLevel = props.nestedLevel || 0;
+  const parentKey = props.parentKey || "";
+
+  let valueDisplay = "";
+  let valueTooltip = "";
+  if (value === "boolean" || Array.isArray(value)) {
+    valueDisplay = JSON.stringify(value);
+  } else if (typeof value === "string" && value.indexOf("0x") !== -1) {
+    valueDisplay = hexEllipsis(value);
+    valueTooltip = value;
+  } else if (value && typeof value !== "object") {
+    valueDisplay = value;
+  }
+
+  return (
+    <React.Fragment key={parentKey + keyName}>
+      <CredentialTR key={parentKey + keyName}>
+        <CredentialTDLeft>
+          <Box pl={nestedLevel * 24}>{keyName}</Box>
+        </CredentialTDLeft>
+        <CredentialTDRight>
+          {valueTooltip ? (
+            <Tooltip message={valueTooltip} placement="top">
+              <Box>{valueDisplay}</Box>
+            </Tooltip>
+          ) : (
+            valueDisplay
+          )}
+        </CredentialTDRight>
+      </CredentialTR>
+      {value &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        Object.entries(value).map(([nestedKey, nestedValue]) => (
+          <CredentialProperty
+            keyName={nestedKey}
+            value={nestedValue}
+            nestedLevel={nestedLevel + 1}
+            parentKey={parentKey + keyName}
+          />
+        ))}
+    </React.Fragment>
+  );
+};

--- a/src/components/views/Credentials/CredentialProperty.tsx
+++ b/src/components/views/Credentials/CredentialProperty.tsx
@@ -1,19 +1,26 @@
 import * as React from "react";
 import { Box, Tooltip } from "rimble-ui";
+import { Info } from "@rimble/icons";
+import { JsonSchemaNode } from "vc-schema-tools";
 import { hexEllipsis } from "../../../utils/helpers";
 import { CredentialTDLeft, CredentialTDRight, CredentialTR } from "./CredentialComponents";
+import { colors } from "../../../themes/colors";
 
 export interface CredentialPropertyProps {
   keyName: string /** "key" prop name is reserved by React */;
   value: any;
   nestedLevel?: number;
   parentKey?: string;
+  schema?: JsonSchemaNode;
 }
 
 export const CredentialProperty: React.FunctionComponent<CredentialPropertyProps> = (props) => {
-  const { keyName, value } = props;
+  const { schema, keyName, value } = props;
   const nestedLevel = props.nestedLevel || 0;
   const parentKey = props.parentKey || "";
+
+  const keyDisplay = schema?.title || keyName;
+  const keyDescription = schema?.description;
 
   let valueDisplay = "";
   let valueTooltip = "";
@@ -27,10 +34,17 @@ export const CredentialProperty: React.FunctionComponent<CredentialPropertyProps
   }
 
   return (
-    <React.Fragment key={parentKey + keyName}>
-      <CredentialTR key={parentKey + keyName}>
+    <>
+      <CredentialTR>
         <CredentialTDLeft>
-          <Box pl={nestedLevel * 24}>{keyName}</Box>
+          <Box pl={nestedLevel * 24}>
+            {keyDisplay}
+            {keyDescription && (
+              <Tooltip message={keyDescription} placement="top">
+                <Info size={16} color={colors.silver} ml={1} style={{ verticalAlign: "text-bottom" }} />
+              </Tooltip>
+            )}
+          </Box>
         </CredentialTDLeft>
         <CredentialTDRight>
           {valueTooltip ? (
@@ -47,12 +61,14 @@ export const CredentialProperty: React.FunctionComponent<CredentialPropertyProps
         !Array.isArray(value) &&
         Object.entries(value).map(([nestedKey, nestedValue]) => (
           <CredentialProperty
+            key={nestedKey}
             keyName={nestedKey}
             value={nestedValue}
             nestedLevel={nestedLevel + 1}
             parentKey={parentKey + keyName}
+            schema={schema?.properties?.[nestedKey]}
           />
         ))}
-    </React.Fragment>
+    </>
   );
 };

--- a/src/components/views/Schemas/SchemasTable.tsx
+++ b/src/components/views/Schemas/SchemasTable.tsx
@@ -5,9 +5,8 @@ import useSWR from "swr";
 import { SchemaDataResponse } from "..";
 import { colors } from "../../../themes";
 import { TBody, TH, TR } from "../../layouts/LayoutComponents";
-import { ModalContent, ModalFooter, ModalWithX } from "../../elements/Modals";
-import { SchemaDetail } from "./SchemaDetail";
 import { SertoUiContext, SertoUiContextInterface } from "../../../context/SertoUiContext";
+import { ViewSchemaButton } from "./ViewSchemaButton";
 
 export interface SchemasTableProps {
   discover?: boolean;
@@ -17,7 +16,6 @@ export interface SchemasTableProps {
 }
 
 export const SchemasTable: React.FunctionComponent<SchemasTableProps> = (props) => {
-  const [viewedSchema, setViewedSchema] = React.useState<SchemaDataResponse | undefined>();
   const context = React.useContext<SertoUiContextInterface>(SertoUiContext);
 
   const { data, error, isValidating } = useSWR(["getSchemas", !props.discover], () =>
@@ -62,9 +60,7 @@ export const SchemasTable: React.FunctionComponent<SchemasTableProps> = (props) 
                     )}
                   </td>
                   <td style={{ whiteSpace: "nowrap" }}>
-                    <Button.Outline size="small" onClick={() => setViewedSchema(schema)}>
-                      View
-                    </Button.Outline>
+                    <ViewSchemaButton schema={schema} hideIssueVcInDetail={props.hideIssueVcInDetail} />
                     {!props.discover && !props.onSchemaSelect && (
                       <Button.Outline
                         as="a"
@@ -89,16 +85,6 @@ export const SchemasTable: React.FunctionComponent<SchemasTableProps> = (props) 
             })}
           </TBody>
         </Table>
-        <ModalWithX isOpen={!!viewedSchema} close={() => setViewedSchema(undefined)} minWidth={9}>
-          <ModalContent>
-            {viewedSchema && <SchemaDetail schema={viewedSchema} hideIssueVc={props.hideIssueVcInDetail} />}
-          </ModalContent>
-          <ModalFooter mt={3}>
-            <Button width="100%" onClick={() => setViewedSchema(undefined)}>
-              Close
-            </Button>
-          </ModalFooter>
-        </ModalWithX>
       </>
     );
   } else if (error) {

--- a/src/components/views/Schemas/ViewSchemaButton.tsx
+++ b/src/components/views/Schemas/ViewSchemaButton.tsx
@@ -1,26 +1,37 @@
 import * as React from "react";
+import styled from "styled-components";
 import { SchemaDataResponse } from "./types";
 import { Button } from "rimble-ui";
 import { ModalContent, ModalFooter, ModalWithX } from "../../elements/Modals";
 import { SchemaDetail } from "./SchemaDetail";
 
+const Wrapper = styled.span`
+  cursor: pointer;
+  &:hover {
+    opacity: 0.75;
+  }
+`;
+
 export interface ViewSchemaButtonProps {
-  schema: SchemaDataResponse;
+  schema?: SchemaDataResponse;
   hideIssueVcInDetail?: boolean;
 }
 
 export const ViewSchemaButton: React.FunctionComponent<ViewSchemaButtonProps> = (props) => {
+  const { schema, hideIssueVcInDetail } = props;
   const [modalOpen, setModalOpen] = React.useState(false);
+
+  if (!schema) {
+    return <>{props.children}</>;
+  }
 
   return (
     <>
-      <span onClick={() => setModalOpen(true)}>
+      <Wrapper onClick={() => setModalOpen(true)}>
         {props.children || <Button.Outline size="small">View</Button.Outline>}
-      </span>
-      <ModalWithX isOpen={modalOpen} close={() => setModalOpen(false)} minWidth={9}>
-        <ModalContent>
-          {modalOpen && <SchemaDetail schema={props.schema} hideIssueVc={props.hideIssueVcInDetail} />}
-        </ModalContent>
+      </Wrapper>
+      <ModalWithX isOpen={modalOpen} close={() => setModalOpen(false)} minWidth={9} maxWidth={10}>
+        <ModalContent>{modalOpen && <SchemaDetail schema={schema} hideIssueVc={hideIssueVcInDetail} />}</ModalContent>
         <ModalFooter mt={3}>
           <Button width="100%" onClick={() => setModalOpen(false)}>
             Close

--- a/src/components/views/Schemas/ViewSchemaButton.tsx
+++ b/src/components/views/Schemas/ViewSchemaButton.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { SchemaDataResponse } from "./types";
+import { Button } from "rimble-ui";
+import { ModalContent, ModalFooter, ModalWithX } from "../../elements/Modals";
+import { SchemaDetail } from "./SchemaDetail";
+
+export interface ViewSchemaButtonProps {
+  schema: SchemaDataResponse;
+  hideIssueVcInDetail?: boolean;
+}
+
+export const ViewSchemaButton: React.FunctionComponent<ViewSchemaButtonProps> = (props) => {
+  const [modalOpen, setModalOpen] = React.useState(false);
+
+  return (
+    <>
+      <span onClick={() => setModalOpen(true)}>
+        {props.children || <Button.Outline size="small">View</Button.Outline>}
+      </span>
+      <ModalWithX isOpen={modalOpen} close={() => setModalOpen(false)} minWidth={9}>
+        <ModalContent>
+          {modalOpen && <SchemaDetail schema={props.schema} hideIssueVc={props.hideIssueVcInDetail} />}
+        </ModalContent>
+        <ModalFooter mt={3}>
+          <Button width="100%" onClick={() => setModalOpen(false)}>
+            Close
+          </Button>
+        </ModalFooter>
+      </ModalWithX>
+    </>
+  );
+};

--- a/src/services/index.tsx
+++ b/src/services/index.tsx
@@ -1,0 +1,2 @@
+export * from "./SertoSchemasService";
+export * from "./useVcSchema";

--- a/src/services/useVcSchema.ts
+++ b/src/services/useVcSchema.ts
@@ -4,6 +4,7 @@ import { VC, JsonSchema } from "vc-schema-tools";
 import { SertoUiContext, SertoUiContextInterface } from "../context/SertoUiContext";
 import { SchemaDataResponse } from "../components/views/Schemas/types";
 
+/** Same as SchemaDataResponse but the `jsonSchema` string property has been parsed into the actual JSON Schema object. */
 export type SchemaDataResponseWithJsonSchema = SchemaDataResponse & {
   jsonSchema: JsonSchema;
 };
@@ -63,7 +64,7 @@ export function useVcSchema(
                 return withJsonSchema;
               } catch (err) {
                 console.error("Failed to parse JSON Schema:", err);
-                return;
+                continue;
               }
             }
           }

--- a/src/services/useVcSchema.ts
+++ b/src/services/useVcSchema.ts
@@ -1,0 +1,53 @@
+import { useMemo, useContext } from "react";
+import useSWR from "swr";
+import { VC } from "vc-schema-tools";
+import { SertoUiContext, SertoUiContextInterface } from "../context/SertoUiContext";
+import { SchemaDataResponse } from "../components/views/Schemas/types";
+
+/**
+ * Given a VC, returns the Serto Schemas representation of its schema.
+ *
+ * This should probably be implemented with some API that finds schema by VC, but for now we can do it just by just getting all schemas (getSchemas request is probably cached anyway) and searching through it for the right schema.
+ *
+ * @NOTE This only handles VCs issued using Serto Schemas schemas. Some of this functionality could be implemented by fetching @context and/or JSON Schema from the URLs in the VC and transforming those.
+ */
+export function useVcSchema(
+  vc: VC,
+): {
+  loading?: boolean;
+  error?: any;
+  vcSchema?: SchemaDataResponse;
+} {
+  const schemasService = useContext<SertoUiContextInterface>(SertoUiContext).schemasService;
+
+  const { data, error, isValidating: loading } = useSWR("getSchemas", () => schemasService.getSchemas(), {
+    revalidateOnFocus: false,
+  });
+
+  const vcSchema = useMemo(() => {
+    const contextUrls = typeof vc["@context"] === "string" ? [vc["@context"]] : vc["@context"];
+    const types = typeof vc.type === "string" ? [vc.type] : vc.type;
+
+    if (!data || !contextUrls?.length || !types?.length) {
+      return;
+    }
+
+    for (let i = 0; i < data.length; ++i) {
+      for (let j = 0; j < contextUrls.length; ++j) {
+        if (data[i].ldContextPlus.includes(`"jsonLdContext":"${contextUrls[j]}"`)) {
+          for (let k = 0; k < types.length; ++k) {
+            if (data[i].ldContextPlus.includes(`"@rootType":"${types[k]}"`)) {
+              return data[i];
+            }
+          }
+        }
+      }
+    }
+  }, [data, vc]);
+
+  return {
+    loading,
+    error,
+    vcSchema,
+  };
+}


### PR DESCRIPTION
Accidentally closed the previous PR.

Updates to VC component:

- Schema is obtained through a slightly shady hack
- VC title is now the schema's name instead of JSON-LD type
- VC property names use human-readable ones in schema
- Tooltips to show property descriptions from schema
- Schema emoji icon shown in the schema pill
- Clicking on schema pill opens up schema detail modal

We now have a `useVcSchema` hook - you pass in a VC and you get back the full Serto Schemas representation of its schema:

```const { vcSchema, loading, error } = useVcSchema(vc);```