### PR TITLE
build: use regular deepdash instead of ES module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/serto-ui",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "main": "dist/serto-ui.js",
   "types": "dist/serto-ui.d.ts",
   "scripts": {
@@ -33,7 +33,7 @@
   "dependencies": {
     "@rimble/icons": "ConsenSysMesh/rimble-icons",
     "@sindresorhus/slugify": "^1.1.0",
-    "deepdash-es": "^5.3.5",
+    "deepdash": "^5.3.9",
     "prismjs": "^1.23.0",
     "react-scripts": "4.0.1",
     "react-simple-code-editor": "^0.11.0",
@@ -41,7 +41,7 @@
     "swr": "^0.2.2",
     "typescript": "^4.1.3",
     "use-debounce": "^3.4.3",
-    "vc-schema-tools": "^0.2.2"
+    "vc-schema-tools": "^0.2.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.0.1",

--- a/src/components/views/Schemas/utils.ts
+++ b/src/components/views/Schemas/utils.ts
@@ -1,4 +1,4 @@
-import { mapValuesDeep } from "deepdash-es/standalone";
+import mapValuesDeep from "deepdash/mapValuesDeep";
 import { convertToPascalCase } from "../../../utils";
 import { VcSchema, jsonLdContextTypeMap, LdContextPlus, LdContextPlusNode } from "vc-schema-tools";
 import {
@@ -62,7 +62,7 @@ export function createLdContextPlusSchema(
   // @TODO/tobek In the edge case where a nested property has the same ID as another property elsewhere in the schema, the resulting `@id`s will be duplicates which would result in a technically incorrect JSON-LD Context.
   const schemaProperties: { [key: string]: LdContextPlusNode<SchemaMetadata> } = {};
   schema.properties.forEach((prop) => {
-    schemaProperties[prop["@id"]] = mapValuesDeep({ ...prop }, (value, key) => {
+    schemaProperties[prop["@id"]] = mapValuesDeep({ ...prop }, (value: any, key: string) => {
       if (key === "@id") {
         return `schema-id:${value}`;
       } else if (typeof value === "object") {
@@ -134,7 +134,7 @@ export function schemaResponseToWorkingSchema(schemaReponse: SchemaDataResponse)
   // Coming from the completed schema, all of the `@id` values will be namespaced according in JSON-LD context, e.g. a "name" property might have `@id` "schema-id:name". If we leave these intact, when the schema is built again we'll end up with "schema-id:schema-id:name". So deep rename these `@id`s according to their keys, which aren't namespaced:
   const renamedIds = mapValuesDeep(
     { ...propertiesMap },
-    (value, key) => {
+    (value: any, key: string) => {
       if (typeof value === "object" && "@id" in value) {
         return {
           ...value,

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,3 +1,4 @@
+declare module "deepdash/mapValuesDeep";
 declare module "rimble-ui";
 declare module "@rimble/icons";
 declare module "*.png";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5793,13 +5793,6 @@ deep-object-diff@^1.1.0:
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
 
-deepdash-es@^5.3.5:
-  version "5.3.5"
-  resolved "https://registry.yarnpkg.com/deepdash-es/-/deepdash-es-5.3.5.tgz#1217365f6508bb47f1f90def6b4f1c4b5f4ff6eb"
-  integrity sha512-bezxT+LqAu1Ly8I2LAEFle3fdEAc/bHld9cMAbgYzY+69+P9qTkGtNvC2ZQJEP4C1C2Fx9gVn/TCoQlAivWPDA==
-  dependencies:
-    lodash-es "^4.17.15"
-
 deepdash@^5.3.9:
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/deepdash/-/deepdash-5.3.9.tgz#2aa92570d7b1787ed281e2fafe0be24df00ddfe4"
@@ -14542,14 +14535,14 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vc-schema-tools@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/vc-schema-tools/-/vc-schema-tools-0.2.2.tgz#713ba2180f7fcacc7702374f2257b49b2097b23d"
-  integrity sha512-HddjaWDzU20iIzhFHxHZ26ohPteuej+Vgg//1osWi995nhDsG3x3oIIasWayuAqSwFDEPpYfqQDXR6ECM6dlDA==
+vc-schema-tools@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vc-schema-tools/-/vc-schema-tools-0.2.3.tgz#b75ef226fcd8eeeb21d8f04f0b60938064b3d5af"
+  integrity sha512-6NgLCsWxJTE2Veo1WEYvACbglDCKyjcl8N95gK5Z8P3qu2/TgA/hIJUw7ZRIhngXFz9z3J+LOsqhWZ9K2zcT6A==
   dependencies:
     ajv "^6.12.3"
     cross-fetch "^3.1.4"
-    deepdash-es "^5.3.5"
+    deepdash "^5.3.9"
     typescript "^4.1.3"
 
 vendors@^1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5800,6 +5800,14 @@ deepdash-es@^5.3.5:
   dependencies:
     lodash-es "^4.17.15"
 
+deepdash@^5.3.9:
+  version "5.3.9"
+  resolved "https://registry.yarnpkg.com/deepdash/-/deepdash-5.3.9.tgz#2aa92570d7b1787ed281e2fafe0be24df00ddfe4"
+  integrity sha512-GRzJ0q9PDj2T+J2fX+b+TlUa2NlZ11l6vJ8LHNKVGeZ8CfxCuJaCychTq07iDRTvlfO8435jlvVS1QXBrW9kMg==
+  dependencies:
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
@@ -9604,6 +9612,11 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
   integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -9648,6 +9661,11 @@ lodash.uniq@^4.5.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loglevel@^1.6.8:
   version "1.7.1"


### PR DESCRIPTION
Relies on https://github.com/SertoID/vc-schema-tools/pull/5