### PR TITLE
Support messaging flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/serto-ui",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "main": "dist/serto-ui.js",
   "types": "dist/serto-ui.d.ts",
   "scripts": {

--- a/src/components/elements/DidSearchOption.tsx
+++ b/src/components/elements/DidSearchOption.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { Eth } from "@rimble/icons";
 import { Box, Flex, Text } from "rimble-ui";
 import { colors } from "../../themes";
+import { SelectedDid } from "../../types";
 import { hexEllipsis } from "../../utils";
 import { H5 } from "../layouts";
 import { DomainImage, SovrinDidLogo } from "../elements";
@@ -17,11 +18,11 @@ const DidSearchOptionStyled = styled(Box)`
 
 export interface DidSearchOptionProps {
   alias?: string;
-  did: string;
+  did: SelectedDid;
   domain: string;
   imageUrl?: string;
   orgName?: string;
-  onSelect(did: string): void;
+  onSelect(did: SelectedDid): void;
 }
 
 export const DidSearchOption: React.FunctionComponent<DidSearchOptionProps> = (props) => {
@@ -51,8 +52,8 @@ export const DidSearchOption: React.FunctionComponent<DidSearchOptionProps> = (p
 
 export interface DidSearchOptionDidProps {
   alias?: string;
-  did: string;
-  onSelect(did: string): void;
+  did: SelectedDid;
+  onSelect(did: SelectedDid): void;
 }
 
 export const DidSearchOptionDid: React.FunctionComponent<DidSearchOptionDidProps> = (props) => {
@@ -61,21 +62,21 @@ export const DidSearchOptionDid: React.FunctionComponent<DidSearchOptionDidProps
     <DidSearchOptionStyled pl="50px" onClick={() => onSelect(did)}>
       <Flex borderTop={2} pr={3} py={3}>
         <Box mr={1}>
-          {did.includes("did:ethr") && <Eth size="16px" />}
-          {did.includes("did:sov") && <SovrinDidLogo />}
+          {did.did.includes("did:ethr") && <Eth size="16px" />}
+          {did.did.includes("did:sov") && <SovrinDidLogo />}
         </Box>
         {alias ? (
           <Box>
             <Text color={colors.midGray} fontSize={1}>
               {alias}
             </Text>
-            <Text color={colors.silver} fontSize={0} title={did}>
-              {did.includes("did:web") ? did : hexEllipsis(did)}
+            <Text color={colors.silver} fontSize={0} title={did.did}>
+              {did.did.includes("did:web") ? did.did : hexEllipsis(did.did)}
             </Text>
           </Box>
         ) : (
-          <Text color={colors.midGray} fontSize={1} title={did}>
-            {did.includes("did:web") ? did : hexEllipsis(did)}
+          <Text color={colors.midGray} fontSize={1} title={did.did}>
+            {did.did.includes("did:web") ? did.did : hexEllipsis(did.did)}
           </Text>
         )}
       </Flex>

--- a/src/components/views/Credentials/IssueVc/IssueVc.stories.tsx
+++ b/src/components/views/Credentials/IssueVc/IssueVc.stories.tsx
@@ -29,6 +29,7 @@ storiesOf("Credential", module).add("IssueVc flow", () => {
         <SertoUiProvider
           context={{
             issueVc: createMockApiRequest(),
+            sendVc: createMockApiRequest(),
           }}
         >
           <IssueVc identifiers={IDENTIFIERS} onComplete={() => {}} />

--- a/src/components/views/Credentials/IssueVc/IssueVcFormInput.tsx
+++ b/src/components/views/Credentials/IssueVc/IssueVcFormInput.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Box, Checkbox, Input, Field, Text } from "rimble-ui";
+import React, { useState } from "react";
+import { Flash, Box, Checkbox, Input, Field, Text } from "rimble-ui";
 import { JsonSchemaNode } from "vc-schema-tools";
 import { DidSearch } from "../../../elements/DidSearch";
 import { Identifier } from "../../../../types";
@@ -12,11 +12,25 @@ export interface IssueVcFormInputProps {
   identifiers: Identifier[];
   required?: boolean;
   defaultSubjectDid?: string;
+  subjectSupportsMessaging?: boolean;
   onChange(value: any): void;
+  setSubjectSupportsMessaging(supported: boolean): void;
 }
 
 export const IssueVcFormInput: React.FunctionComponent<IssueVcFormInputProps> = (props) => {
-  const { name, node, value, onChange, required, identifiers, defaultSubjectDid } = props;
+  const {
+    name,
+    node,
+    value,
+    onChange,
+    required,
+    identifiers,
+    defaultSubjectDid,
+    subjectSupportsMessaging,
+    setSubjectSupportsMessaging,
+  } = props;
+
+  const [didSearchBlurred, setDidSearchBlurred] = useState(false);
 
   // @TODO/tobek Ideally we could detect DIDs in values other than ones keyed `id` but for that we'd have to traverse the `LdContextPlusNode`s instead of `JsonSchemaNode`s which would be more complicated
   const isDid = name === "id" && node.type === "string" && node.format === "uri";
@@ -39,6 +53,8 @@ export const IssueVcFormInput: React.FunctionComponent<IssueVcFormInputProps> = 
                   [nestedKey]: updatedNestedValue,
                 })
               }
+              subjectSupportsMessaging={subjectSupportsMessaging}
+              setSubjectSupportsMessaging={setSubjectSupportsMessaging}
             />
           ))}
         </Box>
@@ -47,13 +63,26 @@ export const IssueVcFormInput: React.FunctionComponent<IssueVcFormInputProps> = 
 
     if (isDid) {
       return (
-        <DidSearch
-          key={name}
-          onChange={onChange}
-          required={required}
-          identifiers={identifiers}
-          defaultSelectedDid={defaultSubjectDid}
-        />
+        <>
+          <DidSearch
+            key={name}
+            onChange={(val) => {
+              onChange(val.did);
+              setSubjectSupportsMessaging(!!val.messagingSupported);
+            }}
+            onBlur={() => setDidSearchBlurred(true)}
+            required={required}
+            identifiers={identifiers}
+            defaultSelectedDid={defaultSubjectDid}
+          />
+          {didSearchBlurred && value && !subjectSupportsMessaging && (
+            <Flash my={3} variant="warning">
+              The subject DID you selected does not support DIDComm messaging, so they cannot seamlessly receive the VC
+              you are issuing. You may still issue the VC here, and on the next screen can share it with the subject via
+              email or QR code.
+            </Flash>
+          )}
+        </>
       );
     }
 

--- a/src/context/SertoUiContext.tsx
+++ b/src/context/SertoUiContext.tsx
@@ -13,6 +13,7 @@ export interface SertoUiContextInterface {
   searchService: Omit<SertoSearchService, "url" | "request">;
   userDids?: Identifier[];
   issueVc?(body: any): Promise<any>;
+  sendVc?(from: string, to: string, vc: { [key: string]: any }): Promise<any>;
 }
 
 export const defaultSertoUiContext: SertoUiContextInterface = {

--- a/src/services/SertoSearchService.ts
+++ b/src/services/SertoSearchService.ts
@@ -1,5 +1,6 @@
 import { config } from "../config";
 import { createMockApiRequest } from "../utils/helpers";
+import { DidSearchResult } from "../types";
 
 export class SertoSearchService {
   public url;
@@ -8,7 +9,7 @@ export class SertoSearchService {
     this.url = url || config.DEFAULT_SEARCH_API_URL;
   }
 
-  public async getEntries(domain?: string): Promise<any> {
+  public async getEntries(domain?: string): Promise<DidSearchResult[]> {
     return this.request("/v1/search/", "POST", { domain });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,33 @@
+export interface DidService {
+  id: string;
+  serviceEndpoint: string;
+  type: string;
+  description?: string;
+}
+
+/** Used internally to represent DIDs returned from Agent. */
 export interface Identifier {
   did: string;
   provider: string;
   alias?: string;
+  services?: DidService[];
+  /** From TrustAgent - deprecated */
   userName?: string;
+  /** From TrustAgent - deprecated */
   userType?: string;
+}
+
+export interface SelectedDid {
+  did: string;
+  messagingSupported?: boolean;
+}
+
+export interface DidSearchResult {
+  domain: string;
+  /** @TODO Multiple DIDs, if present, are comma-separated, but this whole API may change */
+  dids: string;
+  numBaselineEndpoints?: number;
+  numVeramoEndpoints?: number;
 }
 
 export interface DidListing {


### PR DESCRIPTION
Refactors DidSearch and DID types somewhat so that messaging support bubbles up on onChange. Complicates things a bit, and the messaging support logic is very WIP, but we'll see.

Enabling messaging on DIDs isn't built yet, so the only way to fully test this functionality for now is to manually hit the `/v1/messaging/enable/:did` endpoint on your Serto Agent instance, and then you can send VCs to that DID (though receiving VCs doesn't do anything yet).