### PR TITLE
Consolidate and match environment domains/URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/serto-ui",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "main": "dist/serto-ui.js",
   "types": "dist/serto-ui.d.ts",
   "scripts": {

--- a/src/components/elements/DidSearch.tsx
+++ b/src/components/elements/DidSearch.tsx
@@ -1,5 +1,6 @@
 import { useContext, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
+import { config } from "../../config";
 import { SertoUiContext, SertoUiContextInterface } from "../../context/SertoUiContext";
 import { Identifier, DidSearchResult, SelectedDid } from "../../types";
 import { Launch, Search } from "@rimble/icons";
@@ -150,7 +151,7 @@ export const DidSearch: React.FunctionComponent<DidSearchProps> = (props) => {
             )}
           </Box>
           <Flex justifyContent="flex-end" p={3}>
-            <StyledLink href="http://beta.search.serto.id" target="_blank">
+            <StyledLink href={config.SEARCH_UI_URL} target="_blank">
               <Launch color={colors.primary.base} mr={1} size="16px" style={{ verticalAlign: "text-bottom" }} />
               Go to Serto Search
             </StyledLink>

--- a/src/components/views/Credentials/Credential.tsx
+++ b/src/components/views/Credentials/Credential.tsx
@@ -35,7 +35,7 @@ export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
     expirationDate && `${expirationDate.dateFormatted} at ${expirationDate.timeFormatted}`;
   const expired = vc.expirationDate && new Date(vc.expirationDate) < new Date(Date.now());
   const issuer = typeof vc.issuer === "string" ? vc.issuer : vc.issuer.id;
-  const vcUrl = vc.proof?.jwt && `${config.DEFAULT_SEARCH_UI_URL}/vc-validator?vc=${vc.proof.jwt}`;
+  const vcUrl = vc.proof?.jwt && `${config.SEARCH_UI_URL}/vc-validator?vc=${vc.proof.jwt}`;
   const [isOpen, setIsOpen] = useState<boolean>(props.isOpen || false);
 
   return (

--- a/src/components/views/Credentials/CredentialShare/index.tsx
+++ b/src/components/views/Credentials/CredentialShare/index.tsx
@@ -17,7 +17,7 @@ export interface CredentialShareProps {
 
 export const CredentialShare: React.FC<CredentialShareProps> = (props) => {
   const { vc } = props;
-  const vcUrl = `${config.DEFAULT_SEARCH_UI_URL}/vc-validator?vc=${vc.proof.jwt}`;
+  const vcUrl = `${config.SEARCH_UI_URL}/vc-validator?vc=${vc.proof.jwt}`;
   return (
     <>
       <Box borderBottom={4} p={4} pt={0}>

--- a/src/components/views/Schemas/CreateSchema/index.tsx
+++ b/src/components/views/Schemas/CreateSchema/index.tsx
@@ -5,7 +5,7 @@ import { mutate } from "swr";
 import Editor from "react-simple-code-editor";
 import Prism from "prismjs";
 import { useDebounce } from "use-debounce";
-import { config } from "../../../../config";
+import { links } from "../../../../config";
 import { SchemaDataInput, CompletedSchema, baseWorkingSchema, WorkingSchema, SchemaDataResponse } from "../types";
 import { createSchemaInput, ldContextPlusToSchemaInput, schemaResponseToWorkingSchema } from "../utils";
 import { AttributesStep } from "./AttributesStep";
@@ -219,7 +219,7 @@ export const CreateSchema: React.FunctionComponent<CreateSchemaProps> = (props) 
                   JSON-LD Context Plus schema
                 </Link>{" "}
                 spec for more info, and view examples at the{" "}
-                <Link href={config.SCHEMA_PLAYGROUND} target="_blank" fontSize={0}>
+                <Link href={links.SCHEMAS_PLAYGROUND} target="_blank" fontSize={0}>
                   Schema Playground
                 </Link>
                 .

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,76 @@
-const config = {
-  ENVIRONMENT: process.env.NODE_ENV || "development",
-  DEFAULT_SCHEMA_API_URL: "https://beta.api.schemas.serto.id",
-  DEFAULT_CREATE_SCHEMA_PATH: "/schemas/",
-  DEFAULT_SEARCH_API_URL: "https://beta.api.search.serto.id",
-  DEFAULT_SEARCH_UI_URL: "https://beta.search.serto.id",
-  SCHEMA_PLAYGROUND: "https://beta.schemas.serto.id/playground",
+export interface SertoUiConfig {
+  ENVIRONMENT: string;
+  IS_DEV: boolean;
+  FEATURE_FLAGS?: string;
+  SEARCH_API_URL: string;
+  SEARCH_UI_URL: string;
+  SCHEMAS_API_URL: string;
+  SCHEMAS_UI_URL: string;
+}
+
+export const DEV_ENV = "development";
+const ENVIRONMENT = process.env.NODE_ENV || DEV_ENV;
+const domain = window.location.hostname;
+
+export let config: SertoUiConfig = {
+  ENVIRONMENT,
+  IS_DEV: ENVIRONMENT === DEV_ENV,
+  FEATURE_FLAGS: process.env.REACT_APP_FEATURE_FLAGS,
+  SEARCH_API_URL: "http://staging.api.search.serto.id",
+  SEARCH_UI_URL: "http://staging.search.serto.id",
+  SCHEMAS_API_URL: "https://staging.api.schemas.serto.id",
+  SCHEMAS_UI_URL: "https://staging.schemas.serto.id",
 };
 
-export { config };
+if (window.location.protocol.includes("https")) {
+  // staging search doesn't have https, so we gotta use beta or else requests will fail
+  config = {
+    ...config,
+    SEARCH_API_URL: "https://beta.api.search.serto.id",
+    SEARCH_UI_URL: "https://beta.search.serto.id",
+  };
+}
+
+if (ENVIRONMENT !== "development") {
+  if (domain.includes("serto.id") && domain.includes("staging")) {
+    // config above is right
+  } else if (domain.includes("serto.id") && domain.includes("beta")) {
+    config = {
+      ...config,
+      SEARCH_API_URL: "https://beta.api.search.serto.id",
+      SEARCH_UI_URL: "https://beta.search.serto.id",
+      SCHEMAS_API_URL: "https://beta.api.schemas.serto.id",
+      SCHEMAS_UI_URL: "https://beta.schemas.serto.id",
+    };
+  } else {
+    // prod
+    config = {
+      ...config,
+      SEARCH_API_URL: "https://beta.api.search.serto.id",
+      SEARCH_UI_URL: "https://search.serto.id",
+      SCHEMAS_API_URL: "https://beta.api.schemas.serto.id",
+      SCHEMAS_UI_URL: "https://schemas.serto.id",
+    };
+  }
+}
+
+export const links = {
+  SCHEMAS_PLAYGROUND: `${config.SCHEMAS_UI_URL}/playground`,
+  CREATE_SCHEMA_PATH: "/schemas/",
+};
+
+export function mergeServerConfig<T extends { [key: string]: any }>(defaultConfig: T): T {
+  const serverConfigString = (window as any).SERVER_CONFIG;
+  let serverConfig: T | undefined;
+  if (serverConfigString && serverConfigString !== "$ENVIRONMENT") {
+    try {
+      serverConfig = JSON.parse(serverConfigString);
+    } catch (e) {
+      console.error("error parsing server config: ", { serverConfigString, defaultConfig, e });
+    }
+  }
+
+  const config = { ...defaultConfig, ...serverConfig };
+  console.log("config loaded", { config, defaultConfig, serverConfig });
+  return config;
+}

--- a/src/context/SertoUiContext.tsx
+++ b/src/context/SertoUiContext.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Home, Send } from "@rimble/icons";
 
+import { config } from "../config";
 import { SertoSchemasService, mockSertoSchemasService } from "../services/SertoSchemasService";
 import { SertoSearchService, mockSertoSearchService } from "../services/SertoSearchService";
 import { NavItemProps } from "../components/layouts/Global/Nav";
@@ -36,7 +37,7 @@ export const defaultSertoUiContext: SertoUiContextInterface = {
     { text: "Nowhere", url: "/nowhere", icon: Send, section: "nowhere" },
   ],
   schemasService: mockSertoSchemasService,
-  schemasUiUrl: "https://beta.schemas.serto.id",
+  schemasUiUrl: config.SCHEMAS_UI_URL,
   searchService: mockSertoSearchService,
 };
 

--- a/src/serto-ui.ts
+++ b/src/serto-ui.ts
@@ -1,4 +1,5 @@
 export * from "./components";
+export * from "./config";
 export * from "./context";
 export * from "./themes";
 export * from "./types";

--- a/src/services/SertoSchemasService.ts
+++ b/src/services/SertoSchemasService.ts
@@ -1,5 +1,5 @@
 import { SchemaDataInput, SchemaDataResponse } from "../components/views/Schemas/types";
-import { config } from "../config";
+import { config, links } from "../config";
 import { createMockApiRequest } from "../utils/helpers";
 import { JwtUserData } from "../types";
 
@@ -27,11 +27,11 @@ export class SertoSchemasService {
   public createSchemaPath: string;
 
   constructor(url?: string, jwt?: string, userData?: JwtUserData, createSchemaPath?: string) {
-    this.url = url || config.DEFAULT_SCHEMA_API_URL;
+    this.url = url || config.SCHEMAS_API_URL;
     this.jwt = jwt;
     this.userData = userData;
     this.isAuthenticated = !!(jwt && userData);
-    this.createSchemaPath = createSchemaPath || config.DEFAULT_CREATE_SCHEMA_PATH;
+    this.createSchemaPath = createSchemaPath || links.CREATE_SCHEMA_PATH;
   }
 
   /** Build URL at which a given schema will be hosted. */

--- a/src/services/SertoSearchService.ts
+++ b/src/services/SertoSearchService.ts
@@ -6,7 +6,7 @@ export class SertoSearchService {
   public url;
 
   constructor(url?: string) {
-    this.url = url || config.DEFAULT_SEARCH_API_URL;
+    this.url = url || config.SEARCH_API_URL;
   }
 
   public async getEntries(domain?: string): Promise<DidSearchResult[]> {


### PR DESCRIPTION
This uses one central config in serto-ui that picks matching environment domains across search and schemas, based on the current domain. Products inherit the config and override as needed.