### PR TITLE
Yet more updates for schema refactor stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/serto-ui",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "dist/serto-ui.js",
   "types": "dist/serto-ui.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/serto-ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/serto-ui.js",
   "types": "dist/serto-ui.d.ts",
   "scripts": {
@@ -46,7 +46,7 @@
     "swr": "^0.2.2",
     "typescript": "^4.1.3",
     "use-debounce": "^3.4.3",
-    "vc-schema-tools": "^0.2.5"
+    "vc-schema-tools": "^0.3.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "swr": "^0.2.2",
     "typescript": "^4.1.3",
     "use-debounce": "^3.4.3",
-    "vc-schema-tools": "^0.3.2"
+    "vc-schema-tools": "^0.3.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Serto",
   "homepage": "https://serto.id",
   "repository": "SertoID/serto-ui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "dist/serto-ui.js",
   "types": "dist/serto-ui.d.ts",
   "scripts": {

--- a/src/components/views/Credentials/Credential.tsx
+++ b/src/components/views/Credentials/Credential.tsx
@@ -57,14 +57,18 @@ export const Credential: React.FunctionComponent<CredentialProps> = (props) => {
           <Box borderBottom={2} mb={3} pb={1} pt={2} px={3}>
             <Table border={0} boxShadow={0} mb={2} width="100%" style={{ tableLayout: "fixed" }}>
               <tbody>
-                {Object.entries(vc.credentialSubject).map(([key, value]) => (
-                  <CredentialProperty
-                    key={key}
-                    keyName={key}
-                    value={value}
-                    schema={vcSchema?.parsedJsonSchema.properties?.credentialSubject?.properties?.[key]}
-                  />
-                ))}
+                {Object.entries(vc.credentialSubject).map(
+                  ([key, value]) =>
+                    // "type" is a reserved keyword in JSON-LD, and `credentialSubject.type` is just used to define what semantic type of linked data the VC subject is, and we present that info elsewhere as the schema, so would be redundant to list it. Some issuers include `credentialSubject.type` in every single VC.
+                    key !== "type" && (
+                      <CredentialProperty
+                        key={key}
+                        keyName={key}
+                        value={value}
+                        schema={vcSchema?.parsedJsonSchema.properties?.credentialSubject?.properties?.[key]}
+                      />
+                    ),
+                )}
               </tbody>
             </Table>
           </Box>

--- a/src/components/views/Schemas/CreateSchema/AttributesStep.tsx
+++ b/src/components/views/Schemas/CreateSchema/AttributesStep.tsx
@@ -45,6 +45,7 @@ export const AttributesStep: React.FunctionComponent<AttributesStepProps> = (pro
     const propertyIds = new Set();
     let missingField = false;
     let duplicateId = false;
+    let invalidId = false;
     // @TODO/tobek These checks should be recursive. Empty `title`'s are already handled by native browser form checks, but `$linkedData.term` collisions (which would have to be unique only among sibling properties) are not handled.
     Object.entries(schema.properties?.credentialSubject?.properties || {}).forEach(([key, prop]) => {
       if (key === "") {
@@ -52,7 +53,12 @@ export const AttributesStep: React.FunctionComponent<AttributesStepProps> = (pro
       }
 
       if (prop.$linkedData?.term) {
-        if (propertyIds.has(prop.$linkedData.term)) {
+        if (prop.$linkedData?.term === "type") {
+          setError(
+            `An attribute name result in ID "${prop.$linkedData.term}" - this is a reserved keyword in the JSON-LD specification that VCs use. Please use a different name.`,
+          );
+          invalidId = true;
+        } else if (propertyIds.has(prop.$linkedData.term)) {
           setError(
             `Two attribute names result in ID "${prop.$linkedData.term}" - all attributes must have unique IDs.`,
           );
@@ -63,7 +69,7 @@ export const AttributesStep: React.FunctionComponent<AttributesStepProps> = (pro
       }
     });
 
-    if (missingField || duplicateId) {
+    if (missingField || duplicateId || invalidId) {
       setDoValidation(true);
     } else {
       setDoValidation(false);

--- a/src/components/views/Schemas/CreateSchema/AttributesStep.tsx
+++ b/src/components/views/Schemas/CreateSchema/AttributesStep.tsx
@@ -46,17 +46,20 @@ export const AttributesStep: React.FunctionComponent<AttributesStepProps> = (pro
     let missingField = false;
     let duplicateId = false;
     // @TODO/tobek These checks should be recursive. Empty `title`'s are already handled by native browser form checks, but `$linkedData.term` collisions (which would have to be unique only among sibling properties) are not handled.
-    Object.values(schema.properties?.credentialSubject?.properties || {}).forEach((prop) => {
-      if (!prop.title) {
+    Object.entries(schema.properties?.credentialSubject?.properties || {}).forEach(([key, prop]) => {
+      if (key === "") {
         missingField = true;
       }
-      if (!prop.$linkedData?.term) {
-        missingField = true;
-      } else if (propertyIds.has(prop.$linkedData.term)) {
-        setError(`Two attribute names result in ID "${prop.$linkedData.term}" - all attributes must have unique IDs.`);
-        duplicateId = true;
-      } else {
-        propertyIds.add(prop.$linkedData.term);
+
+      if (prop.$linkedData?.term) {
+        if (propertyIds.has(prop.$linkedData.term)) {
+          setError(
+            `Two attribute names result in ID "${prop.$linkedData.term}" - all attributes must have unique IDs.`,
+          );
+          duplicateId = true;
+        } else {
+          propertyIds.add(prop.$linkedData.term);
+        }
       }
     });
 

--- a/src/components/views/Schemas/CreateSchema/AttributesStep.tsx
+++ b/src/components/views/Schemas/CreateSchema/AttributesStep.tsx
@@ -71,7 +71,7 @@ export const AttributesStep: React.FunctionComponent<AttributesStepProps> = (pro
   return (
     <Form validated={doValidation} onSubmit={goNext}>
       {defaultSchemaProperties.map((prop, i) => (
-        <SchemaAttribute key={i + "required"} attr={prop} readOnly={true} />
+        <SchemaAttribute key={i + "required"} attr={prop} readOnly={true} parentRequired={["issuanceDate", "issuer"]} />
       ))}
 
       {schema.properties?.credentialSubject && (

--- a/src/components/views/Schemas/CreateSchema/CreateSchema.stories.tsx
+++ b/src/components/views/Schemas/CreateSchema/CreateSchema.stories.tsx
@@ -24,15 +24,15 @@ const schemaToUpdate = {
   description: "Credential representing employment at an employer.",
   $linkedData: {
     term: "EmploymentCredential",
-    "@id": "https://example.com/schemas/employment-credential/1.0/ld-context.json#",
+    "@id": "https://example.com/schemas/employment-credential/1.0/ld-context.json#EmploymentCredential",
   },
 
   properties: {
     ...baseVcJsonSchema.properties,
     credentialSubject: {
       $linkedData: {
-        term: "credentialSubject",
-        "@id": "https://www.w3.org/2018/credentials#credentialSubject",
+        term: "Employment",
+        "@id": "Employment",
       },
       type: "object",
       required: ["jobTitle", "employer", "employeeSubjectId"],

--- a/src/components/views/Schemas/CreateSchema/CreateSchema.stories.tsx
+++ b/src/components/views/Schemas/CreateSchema/CreateSchema.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import styled from "styled-components";
 import { baseVcJsonSchema } from "vc-schema-tools";
 import { IdentityThemeProvider } from "../../../../themes/IdentityTheme";
 import { CreateSchema } from "./";
@@ -110,10 +111,28 @@ const schemaToUpdate = {
   },
 };
 
+const StyledCreateSchema = styled(CreateSchema)`
+  position: relative;
+
+  max-height: calc(100vh - 50px);
+
+  .right-pane {
+    pre,
+    .schema-formatted-preview {
+      max-height: calc(100vh - 150px);
+      overflow-y: auto;
+    }
+  }
+
+  textarea {
+    box-sizing: inherit;
+  }
+`;
+
 const createSchemaStory = (schemaToUpdate?: WorkingSchema) => () => {
   return (
     <IdentityThemeProvider>
-      <CreateSchema isUpdate={!!schemaToUpdate} initialSchemaState={schemaToUpdate} />
+      <StyledCreateSchema isUpdate={!!schemaToUpdate} initialSchemaState={schemaToUpdate} />
     </IdentityThemeProvider>
   );
 };

--- a/src/components/views/Schemas/CreateSchema/InfoStep.tsx
+++ b/src/components/views/Schemas/CreateSchema/InfoStep.tsx
@@ -82,7 +82,6 @@ export const InfoStep: React.FunctionComponent<InfoStepProps> = (props) => {
           icon: $metadata.icon || defaultIcon,
         },
       });
-      // @TODO set $linkedData based on pascal case and also set ID and URIs or does that happen later?
       props.onComplete();
     } else {
       setDoValidation(true);

--- a/src/components/views/Schemas/CreateSchema/InfoStep.tsx
+++ b/src/components/views/Schemas/CreateSchema/InfoStep.tsx
@@ -65,7 +65,7 @@ export const InfoStep: React.FunctionComponent<InfoStepProps> = (props) => {
     setError("");
     // If *not* authenticated they won't be able to save changes anyway, so we can let them explore the editor without worrying about what values need updating.
     if (isAuthenticated) {
-      if (isUpdate && userOwnsSchema && $metadata.version === initialSchemaState?.version) {
+      if (isUpdate && userOwnsSchema && $metadata.version === initialSchemaState?.$metadata?.version) {
         setError("You must update the version number when updating a schema.");
         return;
       }

--- a/src/components/views/Schemas/CreateSchema/SchemaAttribute.tsx
+++ b/src/components/views/Schemas/CreateSchema/SchemaAttribute.tsx
@@ -242,6 +242,7 @@ export const SchemaAttribute: React.FunctionComponent<SchemaAttributeProps> = (p
           checked={attr.$linkedData?.term && parentRequired?.includes(attr.$linkedData?.term)}
           onChange={toggleRequired}
           disabled={readOnly}
+          mt={readOnly ? 2 : 0}
         />
         {attr.type === "object" && (
           <Button.Text onClick={addNestedAttribute} fontSize={1}>

--- a/src/components/views/Schemas/CreateSchema/index.tsx
+++ b/src/components/views/Schemas/CreateSchema/index.tsx
@@ -241,19 +241,20 @@ export const CreateSchema: React.FunctionComponent<CreateSchemaProps> = (props) 
             <Flash variant="warning" mt={-2} mb={3}>
               <Text fontSize={0}>
                 Warning: This feature is for advanced users, and it is possible to create an unusable schema. Please
-                check the preview on the right to ensure that your schema is as intended. You may also view the{" "}
+                check the preview on the right to ensure that your schema is as intended. The expected format is JSON
+                Schema{" "}
                 <Link
-                  href="https://docs.google.com/document/d/1l41XsI1nTCxx3T6IpAV59UkBrMfRzC89TZRPYiDjOC4/edit?usp=sharing"
+                  href="https://github.com/w3c-ccg/traceability-vocab#ontology-structure"
                   target="_blank"
                   fontSize={0}
                 >
-                  JSON-LD Context Plus schema
-                </Link>{" "}
-                spec for more info, and view examples at the{" "}
+                  with embedded JSON-LD data
+                </Link>
+                . View examples at the{" "}
                 <Link href={links.SCHEMAS_PLAYGROUND} target="_blank" fontSize={0}>
                   Schema Playground
                 </Link>
-                .
+                , or start with the UI editor and then adjust as needed.
               </Text>
             </Flash>
             <PrismHighlightedCodeWrap

--- a/src/components/views/Schemas/CreateSchema/index.tsx
+++ b/src/components/views/Schemas/CreateSchema/index.tsx
@@ -18,6 +18,7 @@ import { SertoUiContext, SertoUiContextInterface } from "../../../../context/Ser
 import { SchemaDetail } from "../SchemaDetail";
 import { Popup, PopupGroup } from "../../../elements/Popup/Popup";
 import { PrismHighlightedCodeWrap } from "../../../elements/HighlightedJson/HighlightedJson";
+import { convertToPascalCase } from "../../../../utils/helpers";
 
 const STEPS = ["INFO", "ATTRIBUTES", "CONFIRM", "DONE"];
 
@@ -107,10 +108,19 @@ export const CreateSchema: React.FunctionComponent<CreateSchemaProps> = (props) 
   }, [debouncedSchema, onSchemaUpdate]);
 
   function updateSchema(updates: Partial<WorkingSchema>) {
-    setSchema({
+    const newSchema = {
       ...schema,
       ...updates,
-    });
+    };
+    if (updates.title) {
+      const subjectLdTerm = convertToPascalCase(updates.title);
+      const credLdTerm = subjectLdTerm + "Credential";
+      newSchema.$linkedData = { term: credLdTerm, "@id": credLdTerm };
+      if (newSchema.properties?.credentialSubject) {
+        newSchema.properties.credentialSubject.$linkedData = { term: subjectLdTerm, "@id": subjectLdTerm };
+      }
+    }
+    setSchema(newSchema);
   }
 
   function goBack() {

--- a/src/components/views/Schemas/SchemaCards.stories.tsx
+++ b/src/components/views/Schemas/SchemaCards.stories.tsx
@@ -7,12 +7,15 @@ import { IdentityThemeProvider } from "../../../themes/IdentityTheme";
 import { SertoUiProvider } from "../../../context/SertoUiProvider";
 import { SchemaCards } from "./SchemaCards";
 
-const schemas = Object.values(EXAMPLE_SCHEMAS)
-  .map((schema) => {
+const schemas = Object.entries(EXAMPLE_SCHEMAS)
+  .map(([key, schema]) => {
+    if (key === "[no schema]") {
+      return undefined;
+    }
     try {
       return jsonSchemaToSchemaInput(schema);
     } catch (err) {
-      console.error("failed to create schema input", err);
+      console.error(`failed to create schema input for schema "${key}"`, err);
       return undefined;
     }
   })

--- a/src/components/views/Schemas/SchemaDetail.tsx
+++ b/src/components/views/Schemas/SchemaDetail.tsx
@@ -103,11 +103,13 @@ export const SchemaDetail: React.FunctionComponent<SchemaDetailProps> = (props) 
                       {userOwnsSchema && " (you)"}
                     </Text>
                   )}
-                  <UserLink href={`https://github.com/${schema.creator.nickName}`} target="_blank">
-                    <GitHub style={{ width: 16, height: "auto" }} />
-                    {schema.creator.nickName}
-                    <OpenInNew size="16px" />
-                  </UserLink>
+                  {schema.creator.identifier.includes("github") && (
+                    <UserLink href={`https://github.com/${schema.creator.nickName}`} target="_blank">
+                      <GitHub style={{ width: 16, height: "auto" }} />
+                      {schema.creator.nickName}
+                      <OpenInNew size="16px" />
+                    </UserLink>
+                  )}
                 </>
               ) : (
                 <i>Author details coming soon</i>

--- a/src/components/views/Schemas/SchemaPlayground.tsx
+++ b/src/components/views/Schemas/SchemaPlayground.tsx
@@ -119,11 +119,11 @@ export const SchemaPlayground: React.FunctionComponent = () => {
                 <Text fontSize={1} style={{ wordBreak: "break-word", float: "left", display: "inline-block" }}>
                   {inputVcValidityMessage}
                 </Text>
-                <Tooltip placement="top" message="@context output below left will be added to the VC sent to the tool">
+                <Tooltip placement="top" message="@context output below will be added to the VC sent to the tool">
                   <Text fontSize={1} style={{ float: "right", display: "inline-block" }}>
                     Open in{" "}
-                    <Button.Outline size="small" onClick={() => vcSchema?.openGoogleJsonLdValidatorPage(inputVc)}>
-                      Google JSON-LD Tool
+                    <Button.Outline size="small" onClick={() => vcSchema?.openJsonLdChecker(inputVc)}>
+                      JSON-LD Checker
                     </Button.Outline>
                     <Button.Outline size="small" ml={2} onClick={() => vcSchema?.openJsonLdPlaygroundPage(inputVc)}>
                       JSON-LD Playground

--- a/src/components/views/Schemas/SchemaPreview.tsx
+++ b/src/components/views/Schemas/SchemaPreview.tsx
@@ -116,11 +116,19 @@ export const SchemaPreview: React.FunctionComponent<SchemaPreviewProps> = (props
     if (!schemaInstance) {
       return {};
     }
+    let jsonLdContextString: string;
+    if (schema.ldContextPlus) {
+      // old format with manually created LD context, so use that:
+      jsonLdContextString = schema.ldContext;
+    } else {
+      // new format, with manually created JSON Schema and schema instance will have generated JSON LD context from that:
+      jsonLdContextString = schemaInstance?.getJsonLdContextString(true);
+    }
     return {
       [SCHEMA_VIEWS[1]]: schemaInstance?.getJsonSchemaString(true),
-      [SCHEMA_VIEWS[2]]: schemaInstance?.getJsonLdContextString(true),
+      [SCHEMA_VIEWS[2]]: jsonLdContextString,
     };
-  }, [schemaInstance]);
+  }, [schemaInstance, schema.ldContext, schema.ldContextPlus]);
 
   const credentialSubject = React.useMemo(() => {
     const credentialSubject = schemaInstance?.jsonSchema?.properties?.credentialSubject as JsonSchemaNode;

--- a/src/components/views/Schemas/SchemaPreview.tsx
+++ b/src/components/views/Schemas/SchemaPreview.tsx
@@ -49,10 +49,6 @@ const renderProperty = (key: string, prop: JsonSchemaNode, required?: boolean): 
   if (prop.type === "object") {
     // Looks nicer with blank type name - nested object will be displayed underneath
     propType = "";
-  } else if (prop.$ref) {
-    propType = "ref: " + prop.$ref;
-  } else if (prop.type === "array" && prop.items?.$ref) {
-    propType = `List (ref: ${prop.items.$ref})`;
   } else {
     propType = nodeToTypeName(prop);
     if (!propType) {

--- a/src/components/views/Schemas/SchemaUsage.tsx
+++ b/src/components/views/Schemas/SchemaUsage.tsx
@@ -10,7 +10,8 @@ import { HighlightedJson } from "../../elements/HighlightedJson/HighlightedJson"
 import { Tabs } from "../../layouts/Tabs/Tabs";
 import { ModalContent, ModalWithX } from "../../elements/Modals";
 import { PopupGroup } from "../../elements/Popup/Popup";
-import { getLdTypesFromSchemaResponse } from "./utils";
+import { getLdTypesFromSchemaResponse, getSchemaUris } from "./utils";
+import { links } from "../../../config";
 
 const StyledTabs = styled(Tabs)`
   li:first-child {
@@ -33,10 +34,9 @@ export const SchemaUsage: React.FunctionComponent<SchemaUsageProps> = (props) =>
   const [urlTab, setUrlTab] = useState("jsonLd");
   const [issueTab, setIssueTab] = useState("sertoAgent");
   const [infoModalOpen, setInfoModalOpen] = useState(false);
-  const [privateBetaModalOpen, setPrivateBetaModalOpen] = useState(false);
   const [exampleVcModalOpen, setExampleVcModalOpen] = useState(false);
 
-  const uris = schema.uris || JSON.parse(schema.jsonSchema)?.$metadata?.uris;
+  const uris = getSchemaUris(schema);
 
   const { subjectLdType, credLdType } = getLdTypesFromSchemaResponse(schema);
   // @TODO/tobek Need a more elegant way to do this, probably VcSchema library should have a utility that creates an example VC that actually has all the fields filled in based on schema.
@@ -135,7 +135,7 @@ export const SchemaUsage: React.FunctionComponent<SchemaUsageProps> = (props) =>
                   <Text fontSize={0} my={2}>
                     Use Serto Agent, our user-friendly admin tool, to issue VCs.
                   </Text>
-                  <Button.Outline size="small" width="100%" onClick={() => setPrivateBetaModalOpen(true)}>
+                  <Button.Outline as="a" size="small" width="100%" href={links.SUITE} target="_blank">
                     <Send size="15px" mr={2} />
                     Issue VC with Serto Agent
                   </Button.Outline>
@@ -201,19 +201,6 @@ export const SchemaUsage: React.FunctionComponent<SchemaUsageProps> = (props) =>
             .
           </Text>
           <Text my={3}></Text>
-        </ModalContent>
-      </ModalWithX>
-
-      <ModalWithX isOpen={privateBetaModalOpen} close={() => setPrivateBetaModalOpen(false)} width={9}>
-        <ModalContent onClick={(e: Event) => e.stopPropagation()}>
-          <Text my={3}>
-            {/*@TODO/tobek Update with link to Serto Agent when launched*/}
-            Serto Agent is still in private beta. Please{" "}
-            <StyledLink href="https://www.serto.id/contact" target="_blank">
-              get in touch
-            </StyledLink>{" "}
-            if you would like to try it out!
-          </Text>
         </ModalContent>
       </ModalWithX>
 

--- a/src/components/views/Schemas/SchemaUsage.tsx
+++ b/src/components/views/Schemas/SchemaUsage.tsx
@@ -10,6 +10,7 @@ import { HighlightedJson } from "../../elements/HighlightedJson/HighlightedJson"
 import { Tabs } from "../../layouts/Tabs/Tabs";
 import { ModalContent, ModalWithX } from "../../elements/Modals";
 import { PopupGroup } from "../../elements/Popup/Popup";
+import { getLdTypesFromSchemaResponse } from "./utils";
 
 const StyledTabs = styled(Tabs)`
   li:first-child {
@@ -35,10 +36,9 @@ export const SchemaUsage: React.FunctionComponent<SchemaUsageProps> = (props) =>
   const [privateBetaModalOpen, setPrivateBetaModalOpen] = useState(false);
   const [exampleVcModalOpen, setExampleVcModalOpen] = useState(false);
 
-  const jsonSchema = JSON.parse(schema.jsonSchema);
-  const uris = schema.uris || jsonSchema?.$metadata?.uris;
+  const uris = schema.uris || JSON.parse(schema.jsonSchema)?.$metadata?.uris;
 
-  const rootType = jsonSchema.$linkedData?.term;
+  const { subjectLdType, credLdType } = getLdTypesFromSchemaResponse(schema);
   // @TODO/tobek Need a more elegant way to do this, probably VcSchema library should have a utility that creates an example VC that actually has all the fields filled in based on schema.
   const exampleVc = {
     "@context": ["https://www.w3.org/2018/credentials/v1", ...(uris?.jsonLdContext ? [uris.jsonLdContext] : [])],
@@ -48,10 +48,11 @@ export const SchemaUsage: React.FunctionComponent<SchemaUsageProps> = (props) =>
         type: "JsonSchemaValidator2018",
       },
     }),
-    type: ["VerifiableCredential", ...(rootType ? [rootType] : [])],
+    type: ["VerifiableCredential", ...(credLdType ? [credLdType] : [])],
     issuer: "[ISSUER]",
     issuanceDate: "[DATE]",
     credentialSubject: {
+      ...(subjectLdType ? { type: subjectLdType } : {}),
       id: "[SUBJECT]",
       "...": "...",
     },

--- a/src/components/views/Schemas/types.ts
+++ b/src/components/views/Schemas/types.ts
@@ -99,7 +99,6 @@ export const baseWorkingSchema: WorkingSchema = {
   properties: {
     ...baseVcJsonSchema.properties,
     credentialSubject: {
-      $linkedData: { term: "credentialSubject", "@id": "https://www.w3.org/2018/credentials#credentialSubject" },
       type: "object",
       required: [],
       properties: {

--- a/src/components/views/Schemas/types.ts
+++ b/src/components/views/Schemas/types.ts
@@ -1,6 +1,6 @@
 import { baseVcJsonSchema, DefaultSchemaMetadata, JsonSchema, JsonSchemaNode } from "vc-schema-tools";
 
-/** Metadata fields specific to our use-case (i.e. not part of the LdContextPlus spec) intended to be passed in to the LdContextPlus generic types where it will be stored in the "@metadata" object. */
+/** Metadata fields specific to our use-case, intended to be stored in the `$metadata` object in a JSON Schema. */
 export interface SchemaMetadata extends DefaultSchemaMetadata {
   version: string;
   slug: string;

--- a/src/components/views/Schemas/types.ts
+++ b/src/components/views/Schemas/types.ts
@@ -39,6 +39,10 @@ export interface SchemaDataResponse extends SchemaDataInput {
     /** JWT subject */
     identifier: string;
   };
+  ipfsHash?: {
+    jsonSchema?: string;
+    ldContext?: string;
+  };
 }
 
 export const defaultSchemaProperties = [

--- a/src/components/views/Schemas/utils.ts
+++ b/src/components/views/Schemas/utils.ts
@@ -55,8 +55,6 @@ export function createSchemaInput(
   };
 }
 
-
-
 export function jsonSchemaToSchemaInput(jsonSchema: JsonSchema): SchemaDataInput {
   if (!jsonSchema.title) {
     throw Error("JSON Schema is missing required property `title`");

--- a/src/components/views/Schemas/utils.ts
+++ b/src/components/views/Schemas/utils.ts
@@ -1,3 +1,4 @@
+import slugify from "@sindresorhus/slugify";
 import { convertToPascalCase } from "../../../utils";
 import { VcSchema, jsonLdSchemaTypeMap, JsonSchema, JsonSchemaNode } from "vc-schema-tools";
 import { SchemaDataInput, WorkingSchema, SchemaMetadata, SchemaDataResponse, newSchemaAttribute } from "./types";
@@ -57,16 +58,19 @@ export function createSchemaInput(
 
 
 export function jsonSchemaToSchemaInput(jsonSchema: JsonSchema): SchemaDataInput {
+  if (!jsonSchema.title) {
+    throw Error("JSON Schema is missing required property `title`");
+  }
+
   const schemaInstance = new VcSchema(jsonSchema);
   const metadata = jsonSchema.$metadata || {};
 
   return {
-    name: jsonSchema.title || metadata.slug,
+    name: jsonSchema.title,
     description: jsonSchema.description,
 
     version: "1.0",
-    slug: "",
-    // @TODO/tobek Handle empty slug in JSON editor
+    slug: slugify(jsonSchema.title),
     ...metadata,
 
     ldContext: schemaInstance.getJsonLdContextString(),

--- a/src/components/views/Schemas/utils.ts
+++ b/src/components/views/Schemas/utils.ts
@@ -1,7 +1,16 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import slugify from "@sindresorhus/slugify";
 import { convertToPascalCase } from "../../../utils";
-import { VcSchema, jsonLdSchemaTypeMap, JsonSchema, JsonSchemaNode } from "vc-schema-tools";
-import { SchemaDataInput, WorkingSchema, SchemaMetadata, SchemaDataResponse, newSchemaAttribute } from "./types";
+import {
+  VcSchema,
+  jsonLdSchemaTypeMap,
+  JsonSchema,
+  JsonSchemaNode,
+  baseVcJsonSchema,
+  jsonSchemaCommentToLinkedData,
+} from "vc-schema-tools";
+import { SchemaDataInput, WorkingSchema, SchemaMetadata, newSchemaAttribute } from "./types";
 import { SertoUiContextInterface } from "../../../context/SertoUiContext";
 
 export const NESTED_TYPE_KEY = "NESTED";
@@ -17,71 +26,112 @@ typeOptions[NESTED_TYPE_KEY] = {
   },
 };
 
-export function createSchemaInput(
-  schema: JsonSchema<SchemaMetadata>,
-  buildSchemaUrl: SertoUiContextInterface["schemasService"]["buildSchemaUrl"],
-): SchemaDataInput {
-  const metadata = schema.$metadata || ({} as SchemaMetadata);
-  const schemaTypeName = convertToPascalCase(schema.title || "");
-  const jsonSchemaUrl = buildSchemaUrl(metadata.slug || "", "json-schema", metadata.version);
-  const jsonLdContextUrl = buildSchemaUrl(metadata.slug || "", "ld-context", metadata.version);
+export function isFullSchema(schema: WorkingSchema): boolean {
+  return !!(schema.$metadata && schema.properties?.credentialSubject);
+}
 
-  const schemaInstance = new VcSchema({
+/** Some imported/pasted schemas (like traceability ones) may only represent `credentialSubject`. This function creates a full JSON Schema document for VC from that: adding required VC properties, nesting schema properties under `credentialSubject`, adding metadata, $id, etc. */
+export function ensureFullSchema(
+  _schema: WorkingSchema,
+  buildSchemaUrl: SertoUiContextInterface["schemasService"]["buildSchemaUrl"],
+): JsonSchema<SchemaMetadata> {
+  if (_schema.$metadata && _schema.properties?.credentialSubject) {
+    return _schema as JsonSchema<SchemaMetadata>;
+  }
+
+  const schema = jsonSchemaCommentToLinkedData(_schema) as JsonSchema<SchemaMetadata>;
+
+  const name = schema.title || "";
+  const slug = schema.$metadata?.slug || slugify(name);
+  const version = schema.$metadata?.version || "1.0";
+
+  const jsonSchemaUrl = buildSchemaUrl(slug, "json-schema", version);
+  const jsonLdContextUrl = buildSchemaUrl(slug, "ld-context", version);
+
+  const ldTypeName = schema.$linkedData?.term || convertToPascalCase(name);
+  const ldId = schema.$linkedData?.["@id"] || jsonLdContextUrl + "#";
+
+  return {
+    $schema: "http://json-schema.org/draft-07/schema#",
     $id: jsonSchemaUrl,
-    ...schema,
+    $linkedData: {
+      term: ldTypeName,
+      "@id": ldId,
+    },
     $metadata: {
-      ...schema.$metadata,
+      slug,
+      version,
       uris: {
         jsonLdContext: jsonLdContextUrl,
         jsonSchema: jsonSchemaUrl,
       },
+      ...schema.$metadata,
+    },
+    title: name,
+    description: schema.description,
+
+    ...baseVcJsonSchema,
+
+    properties: {
+      ...baseVcJsonSchema.properties,
+      credentialSubject: {
+        $linkedData: { term: "credentialSubject", "@id": "https://www.w3.org/2018/credentials#credentialSubject" },
+        type: "object",
+        required: schema.required || [],
+        properties: schema.properties,
+      },
+    },
+  };
+}
+
+/** Take a JSON Schema source, fill in any missing pieces, and wrap it in the metadata expected in the SchemaDataInput type. */
+export function jsonSchemaToSchemaInput(
+  schema: WorkingSchema,
+  buildSchemaUrl?: SertoUiContextInterface["schemasService"]["buildSchemaUrl"],
+): SchemaDataInput {
+  const schemaData = {
+    ...schema,
+    $metadata: {
+      slug: slugify(schema.title || ""),
+      uris: {} as SchemaMetadata["uris"],
+      ...schema.$metadata,
     },
     $linkedData: {
-      term: schemaTypeName,
-      "@id": jsonLdContextUrl + "#",
+      term: convertToPascalCase(schema.title || ""),
+      ...schema.$linkedData,
     },
-  });
+  };
+
+  const metadata = schema.$metadata || ({} as SchemaMetadata);
+  let jsonSchemaUrl = metadata.uris?.jsonSchema;
+  let jsonLdContextUrl = metadata.uris?.jsonLdContext;
+  if (buildSchemaUrl) {
+    jsonSchemaUrl = jsonSchemaUrl || buildSchemaUrl(metadata.slug || "", "json-schema", metadata.version);
+    jsonLdContextUrl = jsonLdContextUrl || buildSchemaUrl(metadata.slug || "", "ld-context", metadata.version);
+  }
+
+  if (jsonSchemaUrl) {
+    schemaData.$id = schemaData.$id || jsonSchemaUrl;
+    if (!schemaData.$metadata?.uris?.jsonSchema) {
+      schemaData.$metadata!.uris!.jsonSchema = jsonSchemaUrl;
+    }
+  }
+  if (jsonLdContextUrl) {
+    if (!schemaData.$linkedData?.["@id"]) {
+      schemaData.$linkedData!["@id"] = jsonLdContextUrl + "#";
+    }
+    if (!schemaData.$metadata?.uris?.jsonSchema) {
+      schemaData.$metadata!.uris!.jsonLdContext = jsonLdContextUrl;
+    }
+  }
+
+  const schemaInstance = new VcSchema(schemaData as JsonSchema);
 
   return {
-    ...metadata,
-    uris: {
-      jsonLdContext: jsonLdContextUrl,
-      jsonSchema: jsonSchemaUrl,
-    },
+    ...(schemaData.$metadata as SchemaMetadata),
     name: schema.title || "",
     description: schema.description,
     ldContext: schemaInstance.getJsonLdContextString(),
     jsonSchema: schemaInstance.getJsonSchemaString(),
   };
-}
-
-export function jsonSchemaToSchemaInput(jsonSchema: JsonSchema): SchemaDataInput {
-  if (!jsonSchema.title) {
-    throw Error("JSON Schema is missing required property `title`");
-  }
-
-  const schemaInstance = new VcSchema(jsonSchema);
-  const metadata = jsonSchema.$metadata || {};
-
-  return {
-    name: jsonSchema.title,
-    description: jsonSchema.description,
-
-    version: "1.0",
-    slug: slugify(jsonSchema.title),
-    ...metadata,
-
-    ldContext: schemaInstance.getJsonLdContextString(),
-    jsonSchema: schemaInstance.getJsonSchemaString(),
-  };
-}
-
-/* Convert API response into local format `WorkingSchema` for managing schema state during UI flow. */
-export function schemaResponseToWorkingSchema(schemaReponse: SchemaDataResponse): WorkingSchema {
-  try {
-    return JSON.parse(schemaReponse.jsonSchema);
-  } catch (err) {
-    console.error("Failed to parse JSON from schema response:", schemaReponse);
-    throw Error("Failed to parse JSON from schema response");
-  }
 }

--- a/src/components/views/Schemas/utils.ts
+++ b/src/components/views/Schemas/utils.ts
@@ -174,3 +174,15 @@ export function getLdTypesFromSchemaResponse(
 
   return { subjectLdType, credLdType };
 }
+
+export function getSchemaUris(
+  schema: SchemaDataInput | SchemaDataResponse,
+): { jsonSchema?: string; jsonLdContext?: string } {
+  if (schema.ipfsHash?.jsonSchema && schema.ipfsHash?.ldContext) {
+    return {
+      jsonSchema: "https://ipfs.infura.io/ipfs/" + schema.ipfsHash.jsonSchema,
+      jsonLdContext: "https://ipfs.infura.io/ipfs/" + schema.ipfsHash.ldContext,
+    };
+  }
+  return schema.uris || JSON.parse(schema.jsonSchema)?.$metadata?.uris;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,6 +55,9 @@ if (ENVIRONMENT !== "development") {
 }
 
 export const links = {
+  CONTACT: "https://www.serto.id/about#contact-section",
+  SUITE: "https://www.serto.id/products",
+  SCHEMAS_FEEDBACK: "https://forms.gle/tGLwuYTc1VkKFmhs6",
   SCHEMAS_PLAYGROUND: `${config.SCHEMAS_UI_URL}/playground`,
   CREATE_SCHEMA_PATH: "/schemas/",
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -15332,10 +15332,10 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vc-schema-tools@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/vc-schema-tools/-/vc-schema-tools-0.3.2.tgz#572eb552da1d8464a1a71101176e4cdbfd1e954b"
-  integrity sha512-6joBKhCUKDEHXMM5LGkl0bLjDWV+Zr/yvxqcjndXJkachIZfg1BJA5bJDPbtBlnQmqNVy1R+1HtEA/gVvj0rCQ==
+vc-schema-tools@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/vc-schema-tools/-/vc-schema-tools-0.3.3.tgz#cb105ffbddbed0f1c86410dae43d38471ec154b3"
+  integrity sha512-sUtS+83s9yK9GRDaSkLocU4B5qMZ4dQLB1CbNriP8wiFTx6tEumG9qDuMUUpdRWQrPriCIz6MncmnobbR45Usg==
   dependencies:
     "@transmute/jsonld-schema" "^0.7.0-unstable.28"
     ajv "^8.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,6 +1608,15 @@
     prop-types "^15.6.2"
     recompose "^0.27.1"
 
+"@digitalbazaar/http-client@^1.1.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@digitalbazaar/http-client/-/http-client-1.2.0.tgz#1ea3661e77000a15bd892a294f20dc6cc5d1c93b"
+  integrity sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==
+  dependencies:
+    esm "^3.2.22"
+    ky "^0.25.1"
+    ky-universal "^0.8.2"
+
 "@discoveryjs/json-ext@^0.5.3":
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
@@ -3127,6 +3136,15 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@transmute/jsonld-schema@^0.7.0-unstable.28":
+  version "0.7.0-unstable.30"
+  resolved "https://registry.yarnpkg.com/@transmute/jsonld-schema/-/jsonld-schema-0.7.0-unstable.30.tgz#4b107c14a7e8532f468737ddb62edd40b85b7bb5"
+  integrity sha512-qar7MIMy6WE4b7do3p65oyQFs7Xm+HDZWB7BSqK3EF/TCV2ReJA9HGtjsCl77eZIkqpc+jBE3jHndPyzuSaLOA==
+  dependencies:
+    ajv "^8.6.1"
+    genson-js "0.0.5"
+    jsonld "^5.2.0"
+
 "@types/anymatch@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-3.0.0.tgz#c95ff14401dbb2869913afac3935af4ad0d37f1a"
@@ -3927,6 +3945,13 @@ abab@^2.0.3, abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -4029,12 +4054,19 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -4042,6 +4074,16 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.6.1, ajv@^8.7.1:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
+  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
@@ -5137,6 +5179,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz#0613c9e6c922e422792e6fcefdf9a3afeee4f8c3"
   integrity sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==
 
+canonicalize@^1.0.1:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.8.tgz#24d1f1a00ed202faafd9bf8e63352cd4450c6df1"
+  integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -6176,6 +6223,11 @@ dargs@^7.0.0:
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
 
+data-uri-to-buffer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
+  integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -6262,14 +6314,6 @@ deep-object-diff@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
-
-deepdash@^5.3.9:
-  version "5.3.9"
-  resolved "https://registry.yarnpkg.com/deepdash/-/deepdash-5.3.9.tgz#2aa92570d7b1787ed281e2fafe0be24df00ddfe4"
-  integrity sha512-GRzJ0q9PDj2T+J2fX+b+TlUa2NlZ11l6vJ8LHNKVGeZ8CfxCuJaCychTq07iDRTvlfO8435jlvVS1QXBrW9kMg==
-  dependencies:
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -7182,6 +7226,11 @@ eslint@^7.18.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+esm@^3.2.22:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
@@ -7244,6 +7293,11 @@ ethereum-blockies@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ethereum-blockies/-/ethereum-blockies-0.1.1.tgz#879fe959deef492a7a92b43dc34ae8dc2ee591fc"
   integrity sha1-h5/pWd7vSSp6krQ9w0ro3C7lkfw=
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^4.0.0:
   version "4.0.7"
@@ -7512,6 +7566,11 @@ fbjs@^0.8.1:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
+
+fetch-blob@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-2.1.2.tgz#a7805db1361bd44c1ef62bb57fb5fe8ea173ef3c"
+  integrity sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -7889,6 +7948,11 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+genson-js@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/genson-js/-/genson-js-0.0.5.tgz#706e2c940d0a9e6790777fb1fe5eb8f82c3d6fa7"
+  integrity sha512-1i1y9MIGzTRkn4TusWQwLWLu8IJGHgSE+fbQRt1fy68ZKEq2GjDZI/7NUSZFOfTbHz8bgjP4iCIOcdYrgEsMBA==
 
 gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -9933,6 +9997,16 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonld@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-5.2.0.tgz#d1e8af38a334cb95edf0f2ae4e2b58baf8d2b5a9"
+  integrity sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==
+  dependencies:
+    "@digitalbazaar/http-client" "^1.1.0"
+    canonicalize "^1.0.1"
+    lru-cache "^6.0.0"
+    rdf-canonize "^3.0.0"
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -10003,6 +10077,19 @@ klona@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
   integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
+
+ky-universal@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/ky-universal/-/ky-universal-0.8.2.tgz#edc398d54cf495d7d6830aa1ab69559a3cc7f824"
+  integrity sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==
+  dependencies:
+    abort-controller "^3.0.0"
+    node-fetch "3.0.0-beta.9"
+
+ky@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-0.25.1.tgz#0df0bd872a9cc57e31acd5dbc1443547c881bfbc"
+  integrity sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA==
 
 language-subtag-registry@~0.3.2:
   version "0.3.21"
@@ -10142,11 +10229,6 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
-
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -10817,6 +10899,14 @@ node-fetch@2.6.1, node-fetch@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@3.0.0-beta.9:
+  version "3.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.0.0-beta.9.tgz#0a7554cfb824380dd6812864389923c783c80d9b"
+  integrity sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==
+  dependencies:
+    data-uri-to-buffer "^3.0.1"
+    fetch-blob "^2.1.1"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -12667,6 +12757,13 @@ raw-loader@^4.0.2:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+rdf-canonize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-3.0.0.tgz#f5bade563e5e58f5cc5881afcba3c43839e8c747"
+  integrity sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==
+  dependencies:
+    setimmediate "^1.0.5"
 
 react-app-polyfill@^2.0.0:
   version "2.0.0"
@@ -15235,14 +15332,15 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vc-schema-tools@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/vc-schema-tools/-/vc-schema-tools-0.2.5.tgz#549cb843eedd5316a181edd0dba9ce8a261e626e"
-  integrity sha512-EgffYGtCO13usY867+5gmuPgOqx5VoYFmH92KVCLDzQhq14CAHnGqYB8GUSDY732NMM1//eEdVxRhIM8Y2B4uA==
+vc-schema-tools@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/vc-schema-tools/-/vc-schema-tools-0.3.2.tgz#572eb552da1d8464a1a71101176e4cdbfd1e954b"
+  integrity sha512-6joBKhCUKDEHXMM5LGkl0bLjDWV+Zr/yvxqcjndXJkachIZfg1BJA5bJDPbtBlnQmqNVy1R+1HtEA/gVvj0rCQ==
   dependencies:
-    ajv "^6.12.3"
+    "@transmute/jsonld-schema" "^0.7.0-unstable.28"
+    ajv "^8.7.1"
+    ajv-formats "^2.1.1"
     cross-fetch "^3.1.4"
-    deepdash "^5.3.9"
     typescript "^4.1.3"
 
 vendors@^1.0.0:


### PR DESCRIPTION
Bugfixes, backwards compatibility fixes to handle old schemas, and fixing an awkward error with how JSON-LD context types were implemented.

Just stacking more PRs onto `tobek/more-format-stuff` as a feature branch until it's ready to merge to main without breaking anything.

Relies on https://github.com/SertoID/vc-schema-tools/pull/11